### PR TITLE
Added book and label methods

### DIFF
--- a/book.rb
+++ b/book.rb
@@ -1,15 +1,17 @@
+require_relative 'item'
+
 class Book < Item
   attr_accessor :publisher, :cover_state
 
-  def initialize(publisher, cover_state)
-    super()
-    @publisher = publisher
-    @cover_state = cover_state
+  def initialize(args)
+    super(args[:genre], args[:author], args[:source], args[:label], args[:publish_date])
+    @publisher = args[:publisher]
+    @cover_state = args[:cover_state]
   end
 
   def can_be_archived?
-    return unless can_be_archived? || (@cover_state = 'bad')
+    return true if super || @cover_state == 'bad'
 
-    @archived = true
+    false
   end
 end


### PR DESCRIPTION
 # Added book and label methods

For this milestone I added the following: 

1. add_item method in the Label class
- should take an instance of the Item class as an input
- should add the input item to the collection of items
- should add self as a property of the item object (by using the correct setter from the item object)
2. can_be_archived?() in the Book class
- should override the method from the parent class
- should return true if the parent's method returns true OR if cover_state equals to "bad"
- otherwise, it should return false

Commands to test these methods:

```
irb

require_relative 'item'
require_relative 'label'
require_relative 'book'

book = Book.new({genre: 'Fiction', author: 'J.K. Rowling', source: 'Library', label: 'Harry Potter and the Philosopher\'s Stone', publish_date: '2022-06-26', publisher: 'Bloomsbury', cover_state: 'bad'})

book.can_be_archived?
book.archived
book.move_to_archive
book.can_be_archived?

label = Label.new("Fiction", "blue")
item = Item.new('genre', 'author', 'source', 'label', '2020-01-01')
label.add_item(item)
puts item.inspect
```